### PR TITLE
Assert the attributes of AK before store it

### DIFF
--- a/server/src/main/java/com/ifx/server/service/CoreService.java
+++ b/server/src/main/java/com/ifx/server/service/CoreService.java
@@ -211,7 +211,12 @@ public class CoreService {
                 return new Response<String>(Response.STATUS_ERROR, "invalid username or password");
             }
             user.setAkPub(attune.getAkPub());
+            if (!TPMEngine.assert_attributes(attune.getAkPub())) {
+                return new Response<String>(Response.STATUS_ERROR, "Wrong attributes of the \"Attestation Key\"");
+            }
             user.setAkName(TPMEngine.computePubKeyName(attune.getAkPub()));
+
+
             user.setEkCrt(attune.getEkCrt());
             user.setEkCrtAttest("Failed");
 

--- a/server/src/main/java/com/ifx/server/tss/TPMEngine.java
+++ b/server/src/main/java/com/ifx/server/tss/TPMEngine.java
@@ -436,6 +436,32 @@ public class TPMEngine {
         }
 
     }
+    /**
+     * Assert the correct attributes of the Attestation Key (AK)
+     * TPM2 tool repository generate AK with the next attributes:
+     * @attributes fixedTPM , fixedParent , sensitiveDataOrigin , userWithAuth , encrypt 
+     * @param pubKey
+     * @return
+     */
+    public static boolean assert_attributes(String pubKey) {
+        byte[] bArray = hexStringToByteArray(pubKey);
+        InByteBuf inBuf = new InByteBuf(bArray);
+        inBuf.readInt(2); // skip length of payload
+        TPMT_PUBLIC pk = new TPMT_PUBLIC();
+        pk.initFromTpm(inBuf);
+        if(pk.objectAttributes.hasAttr(TPMA_OBJECT.fixedTPM)) {
+            if(pk.objectAttributes.hasAttr(TPMA_OBJECT.sensitiveDataOrigin)) {
+                if(pk.objectAttributes.hasAttr(TPMA_OBJECT.userWithAuth)) {
+                    if(pk.objectAttributes.hasAttr(TPMA_OBJECT.restricted)) {
+                        if(pk.objectAttributes.hasAttr(TPMA_OBJECT.encrypt)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
 
     /**
      * Calculate TPM key's Name according to TPM standard


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md

In the original server, the attributes of the Attestation Key (AK) were not asserted before storing the key, therefore, it would store any key that would be provided by the device. 

With makecredential and activatecredential, we are just asserting that the key is loaded in the TPM, but it can be any kind of key, for example, an external key loaded through loadexternal.

To verify that the quote is being generated by the TPM, it has to be signed by an AK, and AK has the next attributes ([reference](https://trustedcomputinggroup.org/wp-content/uploads/TCG_IWG_DevID_v1r2_02dec2020.pdf)):
• Restricted
• Signing
• Not-decrypting
• FixedTPM

But [TPM2 tool](https://github.com/tpm2-software/tpm2-tools) generates the AK with these attributes:
• fixedTPM
• fixedParent
• sensitiveDataOrigin
• userWithAuth
• restricted
• encrypt

I am not sure if these last attributes are the correct ones, but to keep the compatibility with [TPM2 tool](https://github.com/tpm2-software/tpm2-tools), I decided to verify these last ones (I am not checking fixedParent because a key that is fixedTPM will also be fixedParent ([reference](https://trustedcomputinggroup.org/wp-content/uploads/TCG_IWG_DevID_v1r2_02dec2020.pdf)))
